### PR TITLE
Release v1.2.0

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,8 +11,7 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/5383030?v=4",
       "profile": "https://github.com/Sedjj",
       "contributions": [
-        "bug",
-        "ideas"
+        "bug"
       ]
     },
     {
@@ -22,8 +21,7 @@
       "profile": "http://www.ismb.it/vito.macchia",
       "contributions": [
         "code",
-        "bug",
-        "ideas"
+        "bug"
       ]
     },
     {
@@ -42,17 +40,9 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/14031838?v=4",
       "profile": "https://bukhalo.com/",
       "contributions": [
-        "business",
         "code",
         "doc",
-        "example",
-        "ideas",
-        "infra",
-        "maintenance",
-        "projectManagement",
-        "question",
-        "review",
-        "tutorial"
+        "review"
       ]
     },
     {
@@ -61,7 +51,6 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/43011265?v=4",
       "profile": "https://github.com/VyacheslavSaloidWork",
       "contributions": [
-        "question",
         "bug"
       ]
     }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-lib/telegraf.provider.ts

--- a/README.md
+++ b/README.md
@@ -68,32 +68,45 @@ import {
   TelegrafHelp,
   TelegrafOn,
   TelegrafHears,
-  ContextMessageUpdate,
+  Context,
 } from 'nestjs-telegraf';
 
 @Injectable()
 export class AppService {
   @TelegrafStart()
-  start(ctx: ContextMessageUpdate) {
+  start(ctx: Context) {
     ctx.reply('Welcome');
   }
 
   @TelegrafHelp()
-  help(ctx: ContextMessageUpdate) {
+  help(ctx: Context) {
     ctx.reply('Send me a sticker');
   }
 
   @TelegrafOn('sticker')
-  on(ctx: ContextMessageUpdate) {
+  on(ctx: Context) {
     ctx.reply('👍');
   }
 
   @TelegrafHears('hi')
-  hears(ctx: ContextMessageUpdate) {
+  hears(ctx: Context) {
     ctx.reply('Hey there');
   }
 }
 ```
+
+## Bot injection
+At times you may need to access the native `Telegraf` instance. For example, you may want to connect stage middleware. You can inject the Telegraf by using the `@InjectBot()` decorator as follows:
+```typescript
+import { Injectable } from '@nestjs/common';
+import { InjectBot, TelegrafProvider } from 'nestjs-telegraf';
+
+@Injectable()
+export class BotSettingsService {
+  constructor(@InjectBot() private bot: TelegrafProvider) {}
+}
+```
+
 
 ## Async configuration
 When you need to pass module options asynchronously instead of statically, use the forRootAsync() method. As with most dynamic modules, Nest provides several techniques to deal with async configuration.
@@ -112,7 +125,7 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
 
 ```typescript
 TelegrafModule.forRootAsync({
-  imports: [ConfigModule],
+  imports: [ConfigModule.forFeature(telegrafModuleConfig)],
   useFactory: async (configService: ConfigService) => ({
     token: configService.get<string>('TELEGRAM_BOT_TOKEN'),
   }),
@@ -145,7 +158,7 @@ If you want to reuse an existing options provider instead of creating a private 
 
 ```typescript
 TelegrafModule.forRootAsync({
-  imports: [ConfigModule],
+  imports: [ConfigModule.forFeature(telegrafModuleConfig)],
   useExisting: ConfigService,
 });
 ```
@@ -166,7 +179,7 @@ app.use(telegrafProvider.webhookCallback('/secret-path'));
 The last step is to specify launchOptions in `forRoot` method:
 ```typescript
 TelegrafModule.forRootAsync({
-  imports: [ConfigModule],
+  imports: [ConfigModule.forFeature(telegrafModuleConfig)],
   useFactory: async (configService: ConfigService) => ({
     token: configService.get<string>('TELEGRAM_BOT_TOKEN'),
     launchOptions: {
@@ -179,6 +192,7 @@ TelegrafModule.forRootAsync({
   inject: [ConfigService],
 });
 ```
+
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,13 @@
 <p align="center">
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
+  <a href="http://nestjs.com/" target="blank">
+    <img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /
+  </a>
 </p>
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
-
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/core.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
-</p>
-
-## Description
+# NestJS Telegraf
+![npm](https://img.shields.io/npm/dm/nestjs-telegraf)
+![GitHub last commit](https://img.shields.io/github/last-commit/bukhalo/nestjs-telegraf)
+![NPM](https://img.shields.io/npm/l/nestjs-telegraf)
 
 [Telegraf](https://github.com/telegraf/telegraf) module for [NestJS](https://github.com/nestjs/nest).
 
@@ -217,11 +201,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/Sedjj"><img src="https://avatars3.githubusercontent.com/u/5383030?v=4" width="100px;" alt=""/><br /><sub><b>Eldar Salimzebarov</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3ASedjj" title="Bug reports">🐛</a> <a href="#ideas-Sedjj" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="http://www.ismb.it/vito.macchia"><img src="https://avatars3.githubusercontent.com/u/2249342?v=4" width="100px;" alt=""/><br /><sub><b>Vito Macchia</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=lamuertepeluda" title="Code">💻</a> <a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3Alamuertepeluda" title="Bug reports">🐛</a> <a href="#ideas-lamuertepeluda" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/Sedjj"><img src="https://avatars3.githubusercontent.com/u/5383030?v=4" width="100px;" alt=""/><br /><sub><b>Eldar Salimzebarov</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3ASedjj" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="http://www.ismb.it/vito.macchia"><img src="https://avatars3.githubusercontent.com/u/2249342?v=4" width="100px;" alt=""/><br /><sub><b>Vito Macchia</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=lamuertepeluda" title="Code">💻</a> <a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3Alamuertepeluda" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/edgesite"><img src="https://avatars3.githubusercontent.com/u/10336620?v=4" width="100px;" alt=""/><br /><sub><b>KITAHARA SETSUNA</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=edgesite" title="Code">💻</a> <a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3Aedgesite" title="Bug reports">🐛</a></td>
-    <td align="center"><a href="https://bukhalo.com/"><img src="https://avatars2.githubusercontent.com/u/14031838?v=4" width="100px;" alt=""/><br /><sub><b>Aleksandr Bukhalo</b></sub></a><br /><a href="#business-bukhalo" title="Business development">💼</a> <a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=bukhalo" title="Code">💻</a> <a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=bukhalo" title="Documentation">📖</a> <a href="#example-bukhalo" title="Examples">💡</a> <a href="#ideas-bukhalo" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-bukhalo" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-bukhalo" title="Maintenance">🚧</a> <a href="#projectManagement-bukhalo" title="Project Management">📆</a> <a href="#question-bukhalo" title="Answering Questions">💬</a> <a href="https://github.com/bukhalo/nestjs-telegraf/pulls?q=is%3Apr+reviewed-by%3Abukhalo" title="Reviewed Pull Requests">👀</a> <a href="#tutorial-bukhalo" title="Tutorials">✅</a></td>
-    <td align="center"><a href="https://github.com/VyacheslavSaloidWork"><img src="https://avatars3.githubusercontent.com/u/43011265?v=4" width="100px;" alt=""/><br /><sub><b>Vyacheslav Saloid</b></sub></a><br /><a href="#question-VyacheslavSaloidWork" title="Answering Questions">💬</a> <a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3AVyacheslavSaloidWork" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://bukhalo.com/"><img src="https://avatars2.githubusercontent.com/u/14031838?v=4" width="100px;" alt=""/><br /><sub><b>Aleksandr Bukhalo</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=bukhalo" title="Code">💻</a> <a href="https://github.com/bukhalo/nestjs-telegraf/commits?author=bukhalo" title="Documentation">📖</a> <a href="https://github.com/bukhalo/nestjs-telegraf/pulls?q=is%3Apr+reviewed-by%3Abukhalo" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://github.com/VyacheslavSaloidWork"><img src="https://avatars3.githubusercontent.com/u/43011265?v=4" width="100px;" alt=""/><br /><sub><b>Vyacheslav Saloid</b></sub></a><br /><a href="https://github.com/bukhalo/nestjs-telegraf/issues?q=author%3AVyacheslavSaloidWork" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -1,3 +1,4 @@
+export * from './inject-bot.decorator';
 export * from './telegraf-use.decorator';
 export * from './telegraf-on.decorator';
 export * from './telegraf-hears.decorator';

--- a/lib/decorators/inject-bot.decorator.ts
+++ b/lib/decorators/inject-bot.decorator.ts
@@ -1,0 +1,4 @@
+import { Inject } from '@nestjs/common';
+import { TELEGRAF_PROVIDER } from '../telegraf.constants';
+
+export const InjectBot = (): ParameterDecorator => Inject(TELEGRAF_PROVIDER);

--- a/lib/decorators/telegraf-action.decorator.ts
+++ b/lib/decorators/telegraf-action.decorator.ts
@@ -1,8 +1,9 @@
 import { SetMetadata } from '@nestjs/common';
 import { DECORATORS } from '../telegraf.constants';
-import { HearsTriggers } from 'telegraf';
+import { HearsTriggers } from 'telegraf/typings/composer';
+import { Context } from '../interfaces';
 
-export type TelegrafActionTriggers = HearsTriggers;
+export type TelegrafActionTriggers = HearsTriggers<Context>;
 
 export interface TelegrafActionMetadata {
   triggers: TelegrafActionTriggers;

--- a/lib/decorators/telegraf-hears.decorator.ts
+++ b/lib/decorators/telegraf-hears.decorator.ts
@@ -1,8 +1,9 @@
 import { SetMetadata } from '@nestjs/common';
 import { DECORATORS } from '../telegraf.constants';
-import { HearsTriggers } from 'telegraf';
+import { HearsTriggers } from 'telegraf/typings/composer';
+import { Context } from '../interfaces';
 
-export type TelegrafHearsTriggers = HearsTriggers;
+export type TelegrafHearsTriggers = HearsTriggers<Context>;
 
 export interface TelegrafHearsMetadata {
   triggers: TelegrafHearsTriggers;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,10 @@
+export * as Composer from 'telegraf/composer';
+export * as Markup from 'telegraf/markup';
+export * as BaseScene from 'telegraf/scenes/base';
+export * as session from 'telegraf/session';
+export * as Stage from 'telegraf/stage';
+export * as WizardScene from 'telegraf/scenes/wizard';
+
 export * from './telegraf.module';
 export * from './interfaces';
 export * from './decorators';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ export * as session from 'telegraf/session';
 export * as Stage from 'telegraf/stage';
 export * as WizardScene from 'telegraf/scenes/wizard';
 
-export * from './telegraf.module';
-export * from './interfaces';
 export * from './decorators';
+export * from './interfaces';
+export * from './telegraf.module';
+export * from './telegraf.provider';

--- a/lib/interfaces/context.interface.ts
+++ b/lib/interfaces/context.interface.ts
@@ -3,3 +3,9 @@ import { TelegrafContext } from 'telegraf/typings/context';
 export interface Context extends TelegrafContext {
   [key: string]: any;
 }
+
+/**
+ * Removed type from Telegraf v3.38.0, added for backward compatibility.
+ * TODO: remove on next major release
+ */
+export interface ContextMessageUpdate extends Context {}

--- a/lib/interfaces/context.interface.ts
+++ b/lib/interfaces/context.interface.ts
@@ -1,0 +1,5 @@
+import { TelegrafContext } from 'telegraf/typings/context';
+
+export interface Context extends TelegrafContext {
+  [key: string]: any;
+}

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,2 +1,2 @@
-export { ContextMessageUpdate } from 'telegraf';
+export * from './context.interface';
 export * from './telegraf-options.interface';

--- a/lib/interfaces/telegraf-options.interface.ts
+++ b/lib/interfaces/telegraf-options.interface.ts
@@ -3,7 +3,7 @@ import {
   TelegrafOptions,
   LaunchPollingOptions,
   LaunchWebhookOptions,
-} from 'telegraf';
+} from 'telegraf/typings/telegraf';
 
 export interface TelegrafModuleOptions {
   token: string;

--- a/lib/telegraf-core.module.ts
+++ b/lib/telegraf-core.module.ts
@@ -1,3 +1,4 @@
+import { DiscoveryModule } from '@nestjs/core';
 import { Module, DynamicModule, Provider, Type } from '@nestjs/common';
 import {
   TelegrafModuleOptions,
@@ -10,7 +11,6 @@ import {
 } from './telegraf.constants';
 import { TelegrafMetadataAccessor } from './telegraf-metadata.accessor';
 import { TelegrafExplorer } from './telegraf.explorer';
-import { DiscoveryModule } from '@nestjs/core';
 import { TelegrafProvider } from './telegraf.provider';
 
 @Module({

--- a/lib/telegraf.explorer.ts
+++ b/lib/telegraf.explorer.ts
@@ -5,7 +5,6 @@ import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { TelegrafMetadataAccessor } from './telegraf-metadata.accessor';
 import { TelegrafProvider } from './telegraf.provider';
 import { TELEGRAF_PROVIDER } from './telegraf.constants';
-import { Telegraf, ContextMessageUpdate } from 'telegraf';
 import {
   TelegrafActionMetadata,
   TelegrafCashtagMetadata,
@@ -41,9 +40,11 @@ export class TelegrafExplorer implements OnModuleInit {
         return;
       }
 
-      const telegraf = this.moduleRef.get<TelegrafProvider<any>>(
+      const telegraf: TelegrafProvider = this.moduleRef.get<TelegrafProvider>(
         TELEGRAF_PROVIDER,
-        { strict: false },
+        {
+          strict: false,
+        },
       );
 
       this.metadataScanner.scanFromPrototype(
@@ -118,18 +119,14 @@ export class TelegrafExplorer implements OnModuleInit {
     });
   }
 
-  handleTelegrafUse(
-    instance: object,
-    key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
-  ) {
+  handleTelegrafUse(instance: object, key: string, telegraf: TelegrafProvider) {
     telegraf.use(instance[key].bind(instance));
   }
 
   handleTelegrafOn(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafOnMetadata,
   ) {
     telegraf.on(metadata.updateTypes, instance[key].bind(instance));
@@ -138,7 +135,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafHears(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafHearsMetadata,
   ) {
     telegraf.hears(metadata.triggers, instance[key].bind(instance));
@@ -147,7 +144,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafCommand(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafCommandMetadata,
   ) {
     telegraf.command(metadata.commands, instance[key].bind(instance));
@@ -156,7 +153,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafStart(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
   ) {
     telegraf.start(instance[key].bind(instance));
   }
@@ -164,7 +161,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafHelp(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
   ) {
     telegraf.help(instance[key].bind(instance));
   }
@@ -172,7 +169,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafSettings(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
   ) {
     // @ts-ignore
     telegraf.settings(instance[key].bind(instance));
@@ -181,7 +178,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafEntity(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafEntityMetadata,
   ) {
     // @ts-ignore
@@ -191,7 +188,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafMention(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafMentionMetadata,
   ) {
     // @ts-ignore
@@ -201,7 +198,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafPhone(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafPhoneMetadata,
   ) {
     // @ts-ignore
@@ -211,7 +208,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafHashtag(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafHashtagMetadata,
   ) {
     // @ts-ignore
@@ -221,7 +218,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafCashtag(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafCashtagMetadata,
   ) {
     // @ts-ignore
@@ -231,7 +228,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafAction(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafActionMetadata,
   ) {
     telegraf.action(metadata.triggers, instance[key].bind(instance));
@@ -240,7 +237,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafInlineQuery(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
     metadata: TelegrafInlineQueryMetadata,
   ) {
     // @ts-ignore
@@ -250,7 +247,7 @@ export class TelegrafExplorer implements OnModuleInit {
   handleTelegrafGameQuery(
     instance: object,
     key: string,
-    telegraf: Telegraf<ContextMessageUpdate>,
+    telegraf: TelegrafProvider,
   ) {
     telegraf.gameQuery(instance[key].bind(instance));
   }

--- a/lib/telegraf.module.ts
+++ b/lib/telegraf.module.ts
@@ -7,10 +7,11 @@ import {
 
 @Module({})
 export class TelegrafModule {
-  public static forRoot(options?: TelegrafModuleOptions): DynamicModule {
+  public static forRoot(options: TelegrafModuleOptions): DynamicModule {
     return {
       module: TelegrafModule,
       imports: [TelegrafCoreModule.forRoot(options)],
+      exports: [TelegrafCoreModule],
     };
   }
 
@@ -20,6 +21,7 @@ export class TelegrafModule {
     return {
       module: TelegrafModule,
       imports: [TelegrafCoreModule.forRootAsync(options)],
+      exports: [TelegrafCoreModule],
     };
   }
 }

--- a/lib/telegraf.provider.ts
+++ b/lib/telegraf.provider.ts
@@ -5,32 +5,30 @@ import {
   Logger,
   OnApplicationShutdown,
 } from '@nestjs/common';
-import Telegraf, { ContextMessageUpdate } from 'telegraf';
+import { Telegraf } from 'telegraf';
+import { Context, TelegrafModuleOptions } from './interfaces';
 import { TELEGRAF_MODULE_OPTIONS } from './telegraf.constants';
-import { TelegrafModuleOptions } from './interfaces';
 
 @Injectable()
-export class TelegrafProvider<TContext extends ContextMessageUpdate>
-  // @ts-ignore
-  extends Telegraf<TContext>
+export class TelegrafProvider extends Telegraf<Context>
   implements OnApplicationBootstrap, OnApplicationShutdown {
   private logger = new Logger('Telegraf');
-  private launchOptions;
+  private readonly launchOptions;
 
   constructor(@Inject(TELEGRAF_MODULE_OPTIONS) options: TelegrafModuleOptions) {
     super(options.token, options.options);
     this.launchOptions = options.launchOptions;
   }
 
-  onApplicationBootstrap() {
+  async onApplicationBootstrap() {
     this.catch((e) => {
       this.logger.error(e);
     });
 
-    this.launch(this.launchOptions);
+    await this.launch(this.launchOptions);
   }
 
-  async onApplicationShutdown(signal?: string) {
+  async onApplicationShutdown() {
     await this.stop();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2845,9 +2845,9 @@
       }
     },
     "telegraf": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-3.37.0.tgz",
-      "integrity": "sha512-V3448qwfOolBqkIc87yxjW4zMvR2P6AIF24pPTlX9WhZPwA1TF/x3nQhnWPRLtGh2SJuvDcr83iTkXPXT7Opnw==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-3.38.0.tgz",
+      "integrity": "sha512-va4VlrKWp64JrowFoZX/NPzzA6q38kvaIukVXOWFO1V+jR1G8+hCfgJy4TX8Z3rwLJzwaBEet1QhikHDRZWl3A==",
       "requires": {
         "debug": "^4.0.1",
         "minimist": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-telegraf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": ""
   },
   "dependencies": {
-    "telegraf": "3.37.0"
+    "telegraf": "3.38.0"
   },
   "devDependencies": {
     "@nestjs/common": "7.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-telegraf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Telegraf module for NestJS",
   "keywords": [
     "nest",


### PR DESCRIPTION
- Dependencies updated (Fix #65)
- New `@InjectBot` decorator for direct access to `Telegraf` instance (Fix #52)
- Fix some small bugs
- Module now exports embedded `Telegraf` modules such as `Composer`, `Markup`, `BaseScene`, `session`, `Stage`, `WizardScene`.