### PR TITLE
[Refactor] Use exported options types

### DIFF
--- a/lib/interfaces/telegraf-options.interface.ts
+++ b/lib/interfaces/telegraf-options.interface.ts
@@ -1,12 +1,11 @@
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
-import { Middleware } from 'telegraf';
-import { LaunchOptions, TelegrafOptions } from '../types';
+import { Middleware, Telegraf } from 'telegraf';
 
 export interface TelegrafModuleOptions {
   token: string;
   botName?: string;
-  options?: TelegrafOptions;
-  launchOptions?: LaunchOptions;
+  options?: Telegraf.Options<any>;
+  launchOptions?: Telegraf.LaunchOptions;
   include?: Function[];
   middlewares?: ReadonlyArray<Middleware<any>>;
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -16,6 +16,3 @@ export type ComposerMethodArgs<
   T extends Composer<never>,
   U extends OnlyFunctionPropertyNames<T> = OnlyFunctionPropertyNames<T>
 > = Filter<Parameters<T[U]>, Middleware<never>>;
-
-export type LaunchOptions = Parameters<Telegraf['launch']>[0];
-export type TelegrafOptions = ConstructorParameters<typeof Telegraf>[1];


### PR DESCRIPTION
In `4.0.1` version `Telegraf` namespace has been exported. https://github.com/telegraf/telegraf/discussions/1286