### PR TITLE
[Fix] Make options type partial

### DIFF
--- a/lib/interfaces/telegraf-options.interface.ts
+++ b/lib/interfaces/telegraf-options.interface.ts
@@ -4,7 +4,7 @@ import { Middleware, Telegraf } from 'telegraf';
 export interface TelegrafModuleOptions {
   token: string;
   botName?: string;
-  options?: Telegraf.Options<any>;
+  options?: Partial<Telegraf.Options<any>>;
   launchOptions?: Telegraf.LaunchOptions;
   include?: Function[];
   middlewares?: ReadonlyArray<Middleware<any>>;


### PR DESCRIPTION
In constructor Telegraf accept partial `Options` type
https://github.com/telegraf/telegraf/blob/develop/src/telegraf.ts#L81