### PR TITLE
do not launch bot if launchOptions are defined as 'false'

### DIFF
--- a/lib/interfaces/telegraf-options.interface.ts
+++ b/lib/interfaces/telegraf-options.interface.ts
@@ -5,7 +5,7 @@ export interface TelegrafModuleOptions {
   token: string;
   botName?: string;
   options?: Partial<Telegraf.Options<any>>;
-  launchOptions?: Telegraf.LaunchOptions;
+  launchOptions?: Telegraf.LaunchOptions | false;
   include?: Function[];
   middlewares?: ReadonlyArray<Middleware<any>>;
 }

--- a/lib/utils/create-bot-factory.util.ts
+++ b/lib/utils/create-bot-factory.util.ts
@@ -7,7 +7,10 @@ export async function createBotFactory(
   const bot = new Telegraf<any>(options.token, options.options);
 
   bot.use(...(options.middlewares ?? []));
-  await bot.launch(options.launchOptions);
+
+  if (options.launchOptions !== false) {
+    await bot.launch(options.launchOptions);
+  }
 
   return bot;
 }


### PR DESCRIPTION
A quite straightforward and simple solution for the issue https://github.com/bukhalo/nestjs-telegraf/issues/277. Considering backward compatibility