### PR TITLE
Allow updates and scenes to be included from nested imported modules

### DIFF
--- a/lib/services/base-explorer.service.ts
+++ b/lib/services/base-explorer.service.ts
@@ -26,12 +26,28 @@ export class BaseExplorerService {
     modules: Module[],
     callback: (instance: InstanceWrapper, moduleRef: Module) => T | T[],
   ): T[] {
-    const invokeMap = () => {
-      return modules.map((moduleRef) => {
-        const providers = [...moduleRef.providers.values()];
-        return providers.map((wrapper) => callback(wrapper, moduleRef));
-      });
+    const visitedModules = new Set<Module>();
+
+    const unwrap = (moduleRef: Module) => {
+      // protection from circular recursion
+      if (visitedModules.has(moduleRef)) {
+        return [];
+      } else {
+        visitedModules.add(moduleRef);
+      }
+
+      const providers = [...moduleRef.providers.values()];
+      const defined = providers.map((wrapper) => callback(wrapper, moduleRef));
+
+      const imported: (T | T[])[] = moduleRef.imports?.size
+        ? [...moduleRef.imports.values()].reduce((prev, cur) => {
+            return [...prev, ...unwrap(cur)];
+          }, [])
+        : [];
+
+      return [...defined, ...imported];
     };
-    return flattenDeep(invokeMap()).filter(identity);
+
+    return flattenDeep(modules.map(unwrap)).filter(identity);
   }
 }


### PR DESCRIPTION
```typescript
@Module({
  providers: [
    FeatureUpdate, FeatureScene
  ],
})
export class FeatureModule { }

@Module({
  imports: [
    FeatureModule,
  ],
  providers: [
    BotUpdate,
  ],
})
export class BotModule { }

@Module({
  imports: [
    BotModule,
    TelegrafModule.forRootAsync({
      imports: [BotModule],
      useFactory: (configService: ConfigService) => {
        return {
          token: configService.getEnv().bot_token,
          launchOptions: false,
          include: [BotModule],
        };
      },
    }),
  ],
})
export class AppModule { }
```

I have modules for every feature of my bot and as in classic NestJS I expected Controllers (in our case Updates and Scenes) to be propagated to the upper modules where feature module is imported. But they are not

This PR changes `forkMap` method to scan modules recursively