### PR TITLE
Move lodash from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         }
       ],
       "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
         "@commitlint/cli": "12.0.1",
         "@commitlint/config-angular": "12.0.1",
@@ -26,7 +29,6 @@
         "eslint-plugin-prettier": "3.3.1",
         "husky": "5.1.3",
         "lint-staged": "10.5.4",
-        "lodash": "4.17.21",
         "prettier": "2.2.1",
         "reflect-metadata": "0.1.13",
         "rxjs": "6.6.6",
@@ -2789,8 +2791,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "4.0.0",
@@ -6635,8 +6636,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
   "bugs": {
     "url": "https://github.com/bukhalo/nestjs-telegraf/issues"
   },
+  "repository": "git@github.com:bukhalo/nestjs-telegraf.git",
+  "funding": [
+    {
+      "type": "individual",
+      "url": "https://www.tinkoff.ru/sl/95M2htqoxux"
+    }
+  ],
   "license": "MIT",
   "author": "Alexander Bukhalo <a@bukhalo.com>",
   "contributors": [
@@ -26,15 +33,8 @@
       "email": "arthur.asimov.z0@gmail.com"
     }
   ],
-  "funding": [
-    {
-      "type": "individual",
-      "url": "https://www.tinkoff.ru/sl/95M2htqoxux"
-    }
-  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "repository": "git@github.com:bukhalo/nestjs-telegraf.git",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "precommit": "lint-staged",
@@ -42,6 +42,20 @@
     "publish:npm": "npm publish --access public",
     "test": "",
     "typedoc:build": "typedoc --tsconfig ./tsconfig.typedoc.json"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "commit-msg": "commitlint -c .commitlintrc.json -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "lint-staged": {
+    "*.ts": [
+      "prettier --write"
+    ]
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@commitlint/cli": "12.0.1",
@@ -56,7 +70,6 @@
     "eslint-plugin-prettier": "3.3.1",
     "husky": "5.1.3",
     "lint-staged": "10.5.4",
-    "lodash": "4.17.21",
     "prettier": "2.2.1",
     "reflect-metadata": "0.1.13",
     "rxjs": "6.6.6",
@@ -69,16 +82,5 @@
     "@nestjs/core": "^6.7.0 || ^7.0.0",
     "reflect-metadata": "^0.1.13",
     "telegraf": "^4.0.0"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -c .commitlintrc.json -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.ts": [
-      "prettier --write"
-    ]
   }
 }


### PR DESCRIPTION
Resolve https://github.com/bukhalo/nestjs-telegraf/issues/313
I used [sort-package-json](https://www.npmjs.com/package/sort-package-json) for reorganising the package.json
