### PR TITLE
docs: clarify that `AppUpdate` is a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ import { TelegrafModule } from 'nestjs-telegraf';
   imports: [
     TelegrafModule.forRoot({
       token: 'TELEGRAM_BOT_TOKEN',
-    })
+    }),
+    providers: [AppUpdate],
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
just a minor change on the sample snippet to make even clear that `AppUpdate` must be added to the `providers` array of some module