### PR TITLE
chore: bump nestjs version support to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   "devDependencies": {
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-angular": "17.0.3",
-    "@nestjs/common": "8.4.7",
-    "@nestjs/core": "8.4.7",
+    "@nestjs/common": "9.0.0",
+    "@nestjs/core": "9.0.0",
     "@types/lodash": "4.14.182",
     "@typescript-eslint/eslint-plugin": "5.30.5",
     "@typescript-eslint/parser": "5.30.5",
@@ -77,8 +77,8 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.7.0 || ^7.0.0 || ^8.0.0",
-    "@nestjs/core": "^6.7.0 || ^7.0.0 || ^8.0.0",
+    "@nestjs/common": "^6.7.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@nestjs/core": "^6.7.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "reflect-metadata": "^0.1.13",
     "telegraf": "^4.0.0",
     "typescript": "^4.1.2"


### PR DESCRIPTION
references #876