### PR TITLE
fix: remove await before bot.launch

### DIFF
--- a/lib/utils/create-bot-factory.util.ts
+++ b/lib/utils/create-bot-factory.util.ts
@@ -9,7 +9,7 @@ export async function createBotFactory(
   bot.use(...(options.middlewares ?? []));
 
   if (options.launchOptions !== false) {
-    await bot.launch(options.launchOptions);
+    bot.launch(options.launchOptions);
   }
 
   return bot;


### PR DESCRIPTION
Some time before i faced with some strange problem: when i install nestjs-telegraf package in my empty nestjs project and try to start it i dont get some message like "Nest application successfully started".

Then i looked at the code nestjs-telegraf and telegraf and find the root of problem: is simple but strong word - 'await'

I don`t know what consequences the removal can cause but at the moment everything works xD