### PR TITLE
Add support of new NestJS v10 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0 || ^9.0.0",
-    "@nestjs/core": "^8.0.0 || ^9.0.0",
+    "@nestjs/common": "^9.0.0",
+    "@nestjs/core": "^9.0.0",
     "reflect-metadata": "^0.1.13",
     "telegraf": "^4.0.0",
     "typescript": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "reflect-metadata": "^0.1.13",
     "telegraf": "^4.0.0",
     "typescript": "^4.1.2"


### PR DESCRIPTION
Hello,
Looks like no breaking changes introduced with v10 so i think Nest peer deps can be moved to v9 as minimal (following dev deps).