### PR TITLE
Handle bot launch error so the app won't crash

### DIFF
--- a/lib/utils/create-bot-factory.util.ts
+++ b/lib/utils/create-bot-factory.util.ts
@@ -9,7 +9,14 @@ export async function createBotFactory(
   bot.use(...(options.middlewares ?? []));
 
   if (options.launchOptions !== false) {
-    bot.launch(options.launchOptions);
+    bot
+      .launch(options.launchOptions)
+      .catch((err: Error) =>
+        console.error(
+          "Bot launch error. It won't be available until the app restarts.\n",
+          err,
+        ),
+      );
   }
 
   return bot;


### PR DESCRIPTION
I am always annoyed when my app is deployed to Vercel which is serverless (so the app must be started at every function call), there's always a chance for the nestjs-telegraf to throw error API call when launching, such as:

`2023-09-27T05:49:41.056Z	1c417191-68c4-4c4a-bcb5-55210c2e2845	ERROR	Unhandled Promise Rejection 	{"errorType":"Runtime.UnhandledPromiseRejection","errorMessage":"Error: 429: Too Many Requests: retry after 1","reason":{"errorType":"Error","errorMessage":"429: Too Many Requests: retry after 1","code":429,"response":{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 1","parameters":{"retry_after":1}},"on":{"method":"setWebhook","payload":{"url":"https://myapp-a3kd7o5r5-myusername.vercel.app/my-secret-path"}},"stack":["Error: 429: Too Many Requests: retry after 1","    at Telegram.callApi (/var/task/node_modules/.pnpm/telegraf@4.14.0/node_modules/telegraf/lib/core/network/client.js:294:19)","    at processTicksAndRejections (node:internal/process/task_queues:95:5)","    at Telegraf.launch (/var/task/node_modules/.pnpm/telegraf@4.14.0/node_modules/telegraf/lib/telegraf.js:198:9)"]},"promise":{},"stack":["Runtime.UnhandledPromiseRejection: Error: 429: Too Many Requests: retry after 1","    at process.<anonymous> (file:///var/runtime/index.mjs:1250:17)","    at process.emit (node:events:526:35)","    at process.emit (/var/task/___vc/__sourcemap_support.js:602:21)","    at emit (node:internal/process/promises:149:20)","    at processPromiseRejections (node:internal/process/promises:283:27)","    at processTicksAndRejections (node:internal/process/task_queues:96:32)"]}
[ERROR] [1695793781058] LAMBDA_RUNTIME Failed to post handler success response. Http response code: 400.
RequestId: 7b50cdab-42c0-42ee-b707-e2392b984d1b Error: Runtime exited with error: exit status 128
Runtime.ExitError`

So I think it would be better to ignore the error and let the app run without nestjs-telegraf module. Because it's just a webhook and if my app has another API that's called from other client, it won't need the Telegram webhook. In serverless case, it wouldn't matter for Telegram webhook since it will retry to call the endpoint again.