### PR TITLE
fix: add catch when bot launch

### DIFF
--- a/lib/utils/create-bot-factory.util.ts
+++ b/lib/utils/create-bot-factory.util.ts
@@ -9,7 +9,7 @@ export async function createBotFactory(
   bot.use(...(options.middlewares ?? []));
 
   if (options.launchOptions !== false) {
-    bot.launch(options.launchOptions);
+    bot.launch(options.launchOptions).catch((e: any) => console.log(e));
   }
 
   return bot;


### PR DESCRIPTION
Added a method for launching the bot; if it cannot launch, the application does not crash.