### PR TITLE
Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ $ npm i nestjs-telegraf telegraf
 ```
 
 ## Documentation
-Check out the [documentation site](https://nestjs-telegraf.vercel.app).
+Check out the [documentation site](https://nestjs-telegraf.0x467.com/).


### PR DESCRIPTION
Docs was linked to https://nestjs-telegraf.vercel.app/ which gives 404 error
I replaced that with the correct link https://nestjs-telegraf.0x467.com/