### PR TITLE
Fix multi WizardStep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,11 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/ban-types': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };

--- a/lib/decorators/scene/wizard-step.decorator.ts
+++ b/lib/decorators/scene/wizard-step.decorator.ts
@@ -2,5 +2,5 @@ import { SetMetadata } from '@nestjs/common';
 import { WizardStepMetadata } from '../../interfaces';
 import { WIZARD_STEP_METADATA } from '../../telegraf.constants';
 
-export const WizardStep = (step: number) =>
-  SetMetadata<string, WizardStepMetadata>(WIZARD_STEP_METADATA, { step });
+export const WizardStep = (...steps: number[]) =>
+  SetMetadata<string, WizardStepMetadata>(WIZARD_STEP_METADATA, { steps });

--- a/lib/interfaces/scene-metadata.interface.ts
+++ b/lib/interfaces/scene-metadata.interface.ts
@@ -7,5 +7,5 @@ export interface SceneMetadata {
 }
 
 export interface WizardStepMetadata {
-  step: number;
+  steps: number[];
 }

--- a/lib/services/listeners-explorer.service.ts
+++ b/lib/services/listeners-explorer.service.ts
@@ -182,7 +182,10 @@ export class ListenersExplorerService
           basicListeners.push(methodName);
           return undefined;
         }
-        wizardSteps.push({ step: metadata.step, methodName });
+
+        metadata.steps.forEach((step) => {
+          wizardSteps.push({ step, methodName });
+        });
       },
     );
 


### PR DESCRIPTION
## Don't work:
```ts
@WizardStep(2)
@WizardStep(3)
async invalidInput(@Ctx() ctx: WizardContext) {
  await ctx.reply('❌ Invalid Format. Please, try now.');
}
```

## Work, but bad code style:
```ts
@WizardStep(2)
async invalidInput2(@Ctx() ctx: WizardContext) {
  await ctx.reply('❌ Invalid Format. Please, try now.');
}

@WizardStep(3)
async invalidInput3(@Ctx() ctx: WizardContext) {
  await ctx.reply('❌ Invalid Format. Please, try now.');
}
```

## Add in this Pull-Request, good style:
```ts
@WizardStep(2, 3)
async invalidInput(@Ctx() ctx: WizardContext) {
  await ctx.reply('❌ Invalid Format. Please, try now.');
}
```